### PR TITLE
correct hygiene breakage

### DIFF
--- a/lib/macros.sjs
+++ b/lib/macros.sjs
@@ -19,8 +19,8 @@ macro recv {
       }
     }
     body = body.concat(#{$body});
-    return withSyntax($cond = [makeDelim("()", cond, #{$recv})],
-                      $cbody = [makeDelim("{}", body, #{$recv})]) {
+    return withSyntax($cond = [makeDelim("()", cond, #{here})],
+                      $cbody = [makeDelim("{}", body, #{here})]) {
         return #{ if $cond $cbody else }
     }
   }
@@ -28,12 +28,13 @@ macro recv {
 
 macro actor {
   case { $actor $name:ident { $($spec (,) ... => $spbody) (,) ... } } => {
-    return withSyntax($lActor = [makeIdent("Actor", #{$actor})]) {
+    return withSyntax($sender = [makeIdent("sender", #{$actor})], 
+                      $lActor = [makeIdent("Actor", #{$actor})]) {
       return #{
         function $name() { $lActor.call(this); };
         $name.prototype = Object.create($lActor.prototype);
         $name.prototype.constructor = $name;
-        $name.prototype.act = function(sender) {
+        $name.prototype.act = function($sender) {
           $( recv $spec (,) ... => $spbody ) ...
           { return "unsupported"; }
         };


### PR DESCRIPTION
The `sender` wasn't getting bound correctly in the latest version of sweet.js. I think things were "working" before because of a hygiene bug in sweet.js that just got [fixed](https://github.com/mozilla/sweet.js/issues/161). The more correct way of doing it is to create the `sender` binding in the lexical context of `actor`.
